### PR TITLE
compatibility with activerecord-postgres-hstore

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -25,7 +25,7 @@ end
 
 h3. Compatibility with activerecord-postgres-hstore
 
-@activerecord-postgres-hstore@ and @activerecord-postgres-array@ both monkeypatch @ActiveRecord::Base#arel_attributes_values@, which leads to problems if these gems are used together. This gem is aware of @activerecord-postgres-hstore@ and incorporates it in the monkeypatch. However, it is important that @activerecord-postgres-array@ is loaded _after_ @activerecord-postgres-hstore@ for this to work.
+activerecord-postgres-hstore and activerecord-postgres-array both monkeypatch @ActiveRecord::Base#arel_attributes_values@, which leads to problems if these gems are used together. This gem is aware of activerecord-postgres-hstore and incorporates it in the monkeypatch. However, it is important that activerecord-postgres-array is loaded _after_ activerecord-postgres-hstore for this to work.
 
 h2. Current limitations
 

--- a/README.textile
+++ b/README.textile
@@ -23,10 +23,12 @@ end
 
 * When queried, the postgres arrays will be returned as ruby arrays, and vice versa.
 
+h3. Compatibility with activerecord-postgres-hstore
+
+@activerecord-postgres-hstore@ and @activerecord-postgres-array@ both monkeypatch @ActiveRecord::Base#arel_attributes_values@, which leads to problems if these gems are used together. This gem is aware of @activerecord-postgres-hstore@ and incorporates it in the monkeypatch. However, it is important that @activerecord-postgres-array@ is loaded _after_ @activerecord-postgres-hstore@ for this to work.
 
 h2. Current limitations
 
-* Validation of serialised postgres array strings is currently not implemented.
 * Parsing of multi-dimensional postgres array strings is currently not implemented.
 * String and Decimal arrays have been tested, but other array types have not been.  Type casting will need to be implemented for booleans, dates, etc
 

--- a/lib/activerecord-postgres-array/activerecord.rb
+++ b/lib/activerecord-postgres-array/activerecord.rb
@@ -16,6 +16,8 @@ module ActiveRecord
             value = read_attribute(name)
             if column.type.to_s =~ /_array$/ && value && value.is_a?(Array)
               value = value.to_postgres_array(new_record?)
+            elsif defined?(::Hstore) && column.type == :hstore && value && value.is_a?(Hash)
+              value = value.to_hstore
             elsif klass.serialized_attributes.include?(name)
               value = @attributes[name].serialized_value
             end


### PR DESCRIPTION
Right now it is not possible to use these two gems together, this patch restores compatibility.
