### PR TITLE
Postgres syntax of arrays is '#{1,2,3}' (in quotes). But they aren't add...

### DIFF
--- a/lib/activerecord-postgres-array/activerecord.rb
+++ b/lib/activerecord-postgres-array/activerecord.rb
@@ -15,7 +15,7 @@ module ActiveRecord
           if include_readonly_attributes || !self.class.readonly_attributes.include?(name)
             value = read_attribute(name)
             if column.type.to_s =~ /_array$/ && value && value.is_a?(Array)
-              value = value.to_postgres_array(new_record?)
+              value = "'#{value.to_postgres_array(new_record?)}'"
             elsif defined?(::Hstore) && column.type == :hstore && value && value.is_a?(Hash)
               value = value.to_hstore
             elsif klass.serialized_attributes.include?(name)


### PR DESCRIPTION
... automaticly.

Rails 3.0.9 + pg 0.11.0
