### PR TITLE
Simplify array parsing

### DIFF
--- a/lib/activerecord-postgres-array/string.rb
+++ b/lib/activerecord-postgres-array/string.rb
@@ -1,3 +1,4 @@
+require 'csv'
 class String
   def to_postgres_array
     self
@@ -20,9 +21,9 @@ class String
     if empty?
       []
     else
-      elements = match(/\{(.*)\}/).captures.first.gsub(/\\"/, '$ESCAPED_DOUBLE_QUOTE$').split(/(?:,)(?=(?:[^"]|"[^"]*")*$)/)
+      elements = CSV.parse(match(/\{(.*)\}/)[1].gsub(/([^\\])\\"/, '\1""')).first || []
       elements = elements.map do |e|
-        res = e.gsub('$ESCAPED_DOUBLE_QUOTE$', '"').gsub("\\\\", "\\").gsub(/^"/, '').gsub(/"$/, '').gsub("''", "'").strip
+        res = e.gsub("\\\\", "\\").gsub("''","'").strip
         res == 'NULL' ? nil : res
       end
 

--- a/lib/activerecord-postgres-array/string.rb
+++ b/lib/activerecord-postgres-array/string.rb
@@ -20,7 +20,7 @@ class String
     if empty?
       []
     else
-      elements = match(/\{(.*)\}/).captures.first.gsub(/\\"/, '$ESCAPED_DOUBLE_QUOTE$').split(/(,)(?=(?:[^"]|"[^"]*")*$)/).reject {|e| e == ',' }
+      elements = match(/\{(.*)\}/).captures.first.gsub(/\\"/, '$ESCAPED_DOUBLE_QUOTE$').split(/(?:,)(?=(?:[^"]|"[^"]*")*$)/)
       elements = elements.map do |e|
         res = e.gsub('$ESCAPED_DOUBLE_QUOTE$', '"').gsub("\\\\", "\\").gsub(/^"/, '').gsub(/"$/, '').gsub("''", "'").strip
         res == 'NULL' ? nil : res


### PR DESCRIPTION
Hi,

I tried to speed up array parsing a little and simplify the code.
Commit 9ab5d9ed475fafa8b958b54a16da191be27df034 does both, while commit fbb5128d666a98fa9b9b9e6659bf3f045fbf4d44 simplifies the code a lot, but unfortunately also makes it slower...
Cherry-pick whichever you like ;)

Best regards
  Martin
