### PR TITLE
float_array not working properly

### DIFF
--- a/lib/activerecord-postgres-array/activerecord.rb
+++ b/lib/activerecord-postgres-array/activerecord.rb
@@ -73,7 +73,7 @@ module ActiveRecord
       def type_cast_code_with_array(var_name)
         if type.to_s =~ /_array$/
           base_type = type.to_s.gsub(/_array/, '')
-          "#{var_name}.from_postgres_array(:#{base_type})"
+          "#{var_name}.from_postgres_array(:#{base_type.parameterize('_')})"
         else
           type_cast_code_without_array(var_name)
         end

--- a/lib/activerecord-postgres-array/activerecord.rb
+++ b/lib/activerecord-postgres-array/activerecord.rb
@@ -86,6 +86,8 @@ module ActiveRecord
           :decimal_array
         elsif field_type =~ /character varying.*\[\]/
           :string_array
+        elsif field_type =~ /^(?:real|double precision)\[\]$/
+          :float_array
         elsif field_type =~ /\[\]$/
           field_type.gsub(/\[\]/, '_array').to_sym
         else

--- a/lib/activerecord-postgres-array/string.rb
+++ b/lib/activerecord-postgres-array/string.rb
@@ -28,6 +28,8 @@ class String
 
       if base_type == :decimal
         elements.collect(&:to_d)
+      elsif base_type == :float
+        elements.collect(&:to_f)
       elsif base_type == :integer
         elements.collect(&:to_i)
       else

--- a/spec/array_ext_spec.rb
+++ b/spec/array_ext_spec.rb
@@ -11,6 +11,10 @@ describe "Array" do
       [1,2,3].to_postgres_array.should == "'{1,2,3}'"
     end
 
+    it "returns a correct array if used on a float array" do
+      [1.0,2.1,3.2].to_postgres_array.should == "'{1.0,2.1,3.2}'"
+    end
+
     it "returns a correct array if used on a string array" do
       ["Ruby","on","Rails"].to_postgres_array.should == "'{\"Ruby\",\"on\",\"Rails\"}'"
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -47,9 +47,13 @@ describe Article do
 
     it "builds valid arrays" do
       @article.languages = ["English", "German"]
+      @article.prices = [1.2, 1.3]
       @article.save
       @article.reload
       @article.languages_before_type_cast.should == "{English,German}"
+      @article.prices_before_type_cast.should == "{1.2,1.3}"
+      @article.languages.should == ["English", "German"]
+      @article.prices.should == [1.2, 1.3]
     end
 
     it "escapes single quotes correctly" do

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -3,5 +3,6 @@ ActiveRecord::Schema.define do
     t.string        :name
     t.string_array  :languages
     t.integer_array :author_ids
+    t.float_array   :prices
   end
 end


### PR DESCRIPTION
Hi,

I had a problem while defining a column as a float_array and it breaks when reading the attribute from the database.

It seems that the type name of the column is "double precision" with a space and it breaks when transforming it into a symbol.

Adding a parameterize with an underscore as a separator has fixed it.
