### PR TITLE
Rails 3.1.3 support

### DIFF
--- a/activerecord-postgres-array.gemspec
+++ b/activerecord-postgres-array.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   s.summary = s.description
 
-  s.add_dependency "activerecord"
+  s.add_dependency "activerecord", '3.1.3'
+  s.add_development_dependency "rails", '3.1.3'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'pg'

--- a/lib/activerecord-postgres-array/activerecord.rb
+++ b/lib/activerecord-postgres-array/activerecord.rb
@@ -18,8 +18,8 @@ module ActiveRecord
               value = value.to_postgres_array(new_record?)
             elsif defined?(::Hstore) && column.type == :hstore && value && value.is_a?(Hash)
               value = value.to_hstore
-            elsif klass.serialized_attributes.include?(name)
-              value = @attributes[name].serialized_value
+            elsif coder = klass.serialized_attributes[name]
+              value = coder.dump @attributes[name]
             end
             attrs[arel_table[name]] = value
           end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -38,6 +38,20 @@ describe Article do
       article.languages_before_type_cast.should == '{"\\\\","\\""}'
       article.languages.should == ["\\","\""]
     end
+
+    it "handles hash serialization correctly" do
+      article = Article.create(:metadata_hash => { :param1 => "one", :param2 => "two" })
+      article.reload
+      article.metadata_hash.is_a?(Hash).should be_true
+      article.metadata_hash.should == { :param1 => "one", :param2 => "two" }
+    end
+
+    it "handles json serialization correctly" do
+      article = Article.create(:metadata_json => { "param1" => "one", "param2" => "two" })
+      article.reload
+      article.metadata_json.is_a?(Hash).should be_true
+      article.metadata_json.should == { "param1" => "one", "param2" => "two" }
+    end
   end
 
   describe ".update" do

--- a/spec/internal/app/models/article.rb
+++ b/spec/internal/app/models/article.rb
@@ -1,2 +1,4 @@
 class Article < ActiveRecord::Base
+  serialize :metadata_hash, Hash
+  serialize :metadata_json, JSON
 end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -3,5 +3,7 @@ ActiveRecord::Schema.define do
     t.string        :name
     t.string_array  :languages
     t.integer_array :author_ids
+    t.text          :metadata_hash
+    t.text          :metadata_json
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 require 'bundler'
-require 'active_support/dependencies'
+require 'active_support'
 
 Bundler.require :default, :development
 


### PR DESCRIPTION
This commit updates the code to work with ActiveRecord / Rails 3.1.3, to address [issue #20](https://github.com/tlconnor/activerecord-postgres-array/issues/20). See the commit message for full details.

I'm not sure how you'd want to handle this from a versioning perspective, because this is _not_ forward-compatible. Let me know if you'd like me to change it to support both cases, or if you've got a better idea of how to handle it.

Thanks for the helpful gem!
