### PR TITLE
Remove monkey patch of activerecord

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -25,6 +25,12 @@ end
 
 h3. Compatibility with activerecord-postgres-hstore
 
+**Note**
+
+As of activerecord-postgres-hstore '0.7.0', @ActiveRecord::Base#arel_attributes_value@ is not monkey patched and therefore does not interfere with loading of this gem.
+
+If you are using '0.6.0', or earlier, of activerecord-postgres-hstore you must use this gem's version '0.0.8' and the following still applies:
+
 activerecord-postgres-hstore and activerecord-postgres-array both monkeypatch @ActiveRecord::Base#arel_attributes_values@, which leads to problems if these gems are used together. This gem is aware of activerecord-postgres-hstore and incorporates it in the monkeypatch. However, it is important that activerecord-postgres-array is loaded _after_ activerecord-postgres-hstore for this to work.
 
 h2. Current limitations

--- a/lib/activerecord-postgres-array/activerecord.rb
+++ b/lib/activerecord-postgres-array/activerecord.rb
@@ -16,8 +16,6 @@ module ActiveRecord
             value = read_attribute(name)
             if column.type.to_s =~ /_array$/ && value && value.is_a?(Array)
               value = value.to_postgres_array(new_record?)
-            elsif defined?(::Hstore) && column.type == :hstore && value && value.is_a?(Hash)
-              value = value.to_hstore
             elsif klass.serialized_attributes.include?(name)
               value = @attributes[name].serialized_value
             end


### PR DESCRIPTION
According to https://github.com/Tonkpils/activerecord-postgres-hstore/commit/7284b8b063293428292666c7290592ea922ca598 and version '0.7.0' of the activerecord-postgres-hstore gem, their monkey patch of active record has been removed and support for `to_hstore` . This causes the monkeypatch this gem has for compatibility with `activerecord-postgres-hstore` to break.
