### PR TITLE
Fix defaults when dumping ruby schema

### DIFF
--- a/lib/activerecord-postgres-array/activerecord.rb
+++ b/lib/activerecord-postgres-array/activerecord.rb
@@ -96,6 +96,16 @@ module ActiveRecord
       end
       alias_method_chain :type_cast_code, :array
 
+      def type_cast_with_array(value)
+        if value.present? && type.to_s =~ /_array$/
+          base_type = type.to_s.gsub(/_array/, '')
+          value.from_postgres_array(base_type.parameterize('_').to_sym)
+        else
+          type_cast_without_array(value)
+        end
+      end
+      alias_method_chain :type_cast, :array
+
       # Adds the array type for the column.
       def simplified_type_with_array(field_type)
         if field_type =~ /^numeric.+\[\]$/

--- a/spec/array_ext_spec.rb
+++ b/spec/array_ext_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'activerecord-postgres-array/array'
 
-describe "Array" do
+describe Array do
   describe "#to_postgres_array" do
     it "returns '{}' if used on an empty array" do
       [].to_postgres_array.should == "'{}'"
@@ -25,6 +25,13 @@ describe "Array" do
 
     it "escapes backslashes correctly" do
       ["\\","\""].to_postgres_array.should == '\'{"\\\\","\\""}\''
+    end
+  end
+
+  describe "#from_postgres_array" do
+    subject(:array) { [:foo, :bar, :baz] }
+    it "returns the array itself" do
+      array.from_postgres_array.should eq array
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -133,3 +133,14 @@ describe Article do
     end
   end
 end
+
+describe DefaultArticle do
+  it "creates a model with defaults" do
+    article = DefaultArticle.create
+    article.reload
+    article.name.should == 'AbC'
+    article.author_ids.should == [1,2,3]
+    article.prices.should == [12.519267, 16.0]
+    article.defaults.should == ['foo', 'bar', 'baz qux']
+  end
+end

--- a/spec/internal/app/models/default_article.rb
+++ b/spec/internal/app/models/default_article.rb
@@ -1,0 +1,3 @@
+class DefaultArticle < ActiveRecord::Base
+  serialize :serialized_column
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define do
     t.string_array  :languages
     t.integer_array :author_ids
     t.float_array   :prices
+    t.string_array :defaults, :default => ['foo', 'bar']
 
     # To make sure we don't interfere with YAML serialization
     t.string        :serialized_column
@@ -14,4 +15,13 @@ ActiveRecord::Schema.define do
     t.hstore        :hstore_column
   end
   add_hstore_index :articles, :hstore_column
+
+  # Creating a new model table because we don't seem to be able to dump schema for hstore tables well
+  create_table(:default_articles, :force => true) do |t|
+    t.string        :name, :default => 'AbC'
+    t.string_array  :languages
+    t.integer_array :author_ids, :default => [1,2,3]
+    t.float_array   :prices, :default => [12.519267, 16.0]
+    t.string_array :defaults, :default => ['foo', 'bar', 'baz qux']
+  end
 end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "Schema" do
+  subject(:dump_stream) { StringIO.new }
+
+  before { ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, dump_stream) }
+
+  it "can dump the schema" do
+    dump_stream.string.should_not be_blank
+  end
+
+  it "should dump the schema including the array types" do
+    dump_stream.string.should include("t.string_array")
+    dump_stream.string.should include("t.float_array")
+    dump_stream.string.should include("t.integer_array")
+  end
+
+  it "should still dump columns with normal defaults correctly" do
+    dump_stream.string.should include(':default => "AbC"')
+  end
+
+  it "should dump schemas including defaults for string arrays" do
+    dump_stream.string.should include(':default => ["foo", "bar", "baz qux"]')
+  end
+
+  it "should dump schemas including defaults for integer arrays" do
+    dump_stream.string.should include(":default => [1, 2, 3]")
+  end
+
+  it "should dump schemas including defaults for float arrays" do
+    dump_stream.string.should include(":default => [12.519267, 16.0]")
+  end
+end

--- a/spec/string_ext_spec.rb
+++ b/spec/string_ext_spec.rb
@@ -105,5 +105,23 @@ describe "String" do
     it 'correctly handles multi line content' do
       "{A\nB\nC,X\r\nY\r\nZ}".from_postgres_array.should == ["A\nB\nC", "X\r\nY\r\nZ"]
     end
+
+    it 'handles decimal content' do
+      "{15.49151, 16.0}".from_postgres_array(:decimal).should == [15.49151, 16.0]
+    end
+
+    it 'handles float content' do
+      "{15.49151, 16.0}".from_postgres_array(:float).should == [15.49151, 16.0]
+    end
+
+    it 'handles integer content' do
+      "{1,2,3}".from_postgres_array(:integer).should == [1,2,3]
+    end
+
+    it 'handles timestamp content' do
+      t1 = Time.at(628232400)
+      t2 = Time.at(1362018690)
+      "{#{t1},#{t2}}".from_postgres_array(:timestamp).should == [t1, t2]
+    end
   end
 end


### PR DESCRIPTION
I noticed an issue where the schema dump contained the string version of the column default (ie "{foo,bar}"), causing errors when the schema was loaded. 

I did some digging and saw that type_cast gets called to extract the default value when dumping the schema and I added a method chain to detect array columns and properly extract them.
